### PR TITLE
Upgrade plugin to latest Vite transform API

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ts-jest": "^26.1.0",
     "typescript": "^3.9.5",
     "typescript-eslint-language-service": "^3.0.0",
-    "vite": "^0.20.8"
+    "vite": "1.0.0-beta.10"
   },
   "engines": {
     "node": ">= 10"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,23 @@
 import { friendlyJSONstringify } from 'vue-i18n'
 import yaml from 'js-yaml'
 import JSON5 from 'json5'
+import type { Transform } from 'vite'
 
 import { debug as Debug } from 'debug'
 const debug = Debug('vite-plugin-vue-i18n')
 
-type Query = Record<string, string>
+type Query = Record<string, string | string[] | undefined>
+type TransformFn = Transform['transform']
 
-export default function i18n(source: string, query: Query) {
+const i18n: TransformFn = function ({ code, query }) {
   debug('vueSFCTransform: query', JSON.stringify(query))
 
   return new Promise<string>(resolve => {
-    const code = `export default Comp => {
+    const result = `export default Comp => {
   Comp.__i18n = Comp.__i18n || []
-  Comp.__i18n.push(${stringify(parse(source.trim(), query), query)})
+  Comp.__i18n.push(${stringify(parse(code.trim(), query), query)})
 }`.trim()
-    resolve(code)
+    resolve(result)
   })
 }
 
@@ -44,3 +46,5 @@ function parse(source: string, query: Query): string {
       return JSON.parse(value)
   }
 }
+
+export default i18n

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,6 +2655,11 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv-expand@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"
+  integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
+
 dotenv@^8.1.0, dotenv@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
@@ -2774,10 +2779,10 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-esbuild@^0.4.1:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.4.7.tgz#486a8671f628549d329accc8d1c5856ed09ac24e"
-  integrity sha512-J8KXLZKiwxjru9vIQPmpHSjANDgL+QznTG8WNO4mjJirxco1DTMJgY52n82AooXecOBn6BdUiyaW8/i22a55Mw==
+esbuild@^0.5.11:
+  version "0.5.18"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.5.18.tgz#b82f575015c7f3d4326dab0deabf71e52e972122"
+  integrity sha512-kvU6VqPmS7zBN6fPz6zWzu3eHmCFMB92L2cDz6yOWsviz2nIcAnI6bpN7T0mRR+GXbheEIlOj+sjc5a+KxYy/Q==
 
 escape-html@^1.0.3:
   version "1.0.3"
@@ -6258,6 +6263,13 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-discard-comments@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz#1fbabd2c246bff6aaad7997b2b0918f4d7af4033"
+  integrity sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==
+  dependencies:
+    postcss "^7.0.0"
+
 postcss-import@^12.0.1:
   version "12.0.1"
   resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-12.0.1.tgz#cf8c7ab0b5ccab5649024536e565f841928b7153"
@@ -6350,7 +6362,7 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.1, postcss@^7.0.27, postcss@^7.0.28:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.27, postcss@^7.0.28:
   version "7.0.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
   integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
@@ -6919,6 +6931,11 @@ rollup-plugin-vue@^6.0.0-beta.6:
     debug "^4.1.1"
     hash-sum "^2.0.0"
     rollup-pluginutils "^2.8.2"
+
+rollup-plugin-web-worker-loader@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-web-worker-loader/-/rollup-plugin-web-worker-loader-1.3.1.tgz#690059cd114146a60d621b83cf3477129087bb14"
+  integrity sha512-Td36kmB4iz10xqI/gJFCv2xZZ21fY6E7AGVFOT3PWIDkM1BeBrfuzeNh1tFIkD6fHtjQhppnedkYFaIlGHuEvA==
 
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
@@ -8208,10 +8225,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vite@^0.20.8:
-  version "0.20.8"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-0.20.8.tgz#dee70204b2c514cbae37e334cac56f2588791bba"
-  integrity sha512-ZqsDaEKp/rUBLAkOtz+avjFKbOhb38ewesvQmgePg/Y9RcJhmWUqF0cUovFqHNeVamDCdQNLI/kdQMjXg9o87g==
+vite@1.0.0-beta.10:
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-1.0.0-beta.10.tgz#9399d4bd447c37ed3502495d64bb86c188b45bc7"
+  integrity sha512-4YtbXi6RsR4pA/j+MSdrsBLsC7b5sETU8Y12NpUcI20NZgdGzA07xadh5xHk6nQal/ySq5XXnNfQiStYQd1tGw==
   dependencies:
     "@babel/parser" "^7.9.4"
     "@rollup/plugin-commonjs" "^13.0.0"
@@ -8227,8 +8244,9 @@ vite@^0.20.8:
     clean-css "^4.2.3"
     debug "^4.1.1"
     dotenv "^8.2.0"
+    dotenv-expand "^5.1.0"
     es-module-lexer "^0.3.18"
-    esbuild "^0.4.1"
+    esbuild "^0.5.11"
     etag "^1.8.1"
     execa "^4.0.1"
     fs-extra "^9.0.0"
@@ -8248,14 +8266,15 @@ vite@^0.20.8:
     open "^7.0.3"
     ora "^4.0.4"
     postcss "^7.0.28"
+    postcss-discard-comments "^4.0.2"
     postcss-import "^12.0.1"
     postcss-load-config "^2.1.0"
-    postcss-modules "^2.0.0"
     resolve "^1.17.0"
     rollup "^2.11.2"
     rollup-plugin-dynamic-import-variables "^1.0.1"
     rollup-plugin-terser "^5.3.0"
     rollup-plugin-vue "^6.0.0-beta.6"
+    rollup-plugin-web-worker-loader "^1.3.0"
     selfsigned "^1.10.7"
     slash "^3.0.0"
     vue "^3.0.0-beta.14"


### PR DESCRIPTION
The Vite transform API slightly changed during this commit: vitejs/vite@5d9c8f3f338951ac9ca3c6141dedcd5385c43eef. This PR updates Vite to its current latest version in package.json and updates this plugin according to the new API.