### PR TITLE
feat: generate typescript declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
This project is great! Thanks for creating it :smile: It would be great to see the Typescript declarations exported in the distribution. I think this change will do that.

**Before**
```
lib
 - index.js
```

**After**
```
lib
 - index.js
 - index.d.ts
```
```typescript
// index.d.ts
import type { Transform } from 'vite';
declare type TransformFn = Transform['transform'];
declare const i18n: TransformFn;
export default i18n;

```