### PR TITLE
breaking: remove runtimeOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,17 +154,6 @@ About details, See the below section
 
   Note `json` resources matches this option, it will be handled **before the internal json plugin of Vite, and will not be processed afterwards**, else the option doesn't match, the Vite side will handle.
 
-### `runtimeOnly`
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-  Whether or not to use Vue I18n **runtime-only**, set in the `vue-i18n` field of Vite `alias` option.
-
-  If `false` is specified, Vue I18n (vue-i18n) package.json `module` field will be used.
-
-  For more details, See [here](https://vue-i18n-next.intlify.dev/advanced/optimization.html#improve-performance-and-reduce-bundle-size-with-runtime-build-only)
-
 ### `compositionOnly`
 
 - **Type:** `boolean`

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,6 @@ function pluginI18n(
   debug('plugin options:', options)
 
   const filter = createFilter(options.include)
-  const runtimeOnly = isBoolean(options.runtimeOnly)
-    ? options.runtimeOnly
-    : true
   const compositionOnly = isBoolean(options.compositionOnly)
     ? options.compositionOnly
     : true
@@ -45,12 +42,6 @@ function pluginI18n(
     config() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const partialConfig: any = { define: {}, alias: {} }
-
-      if (runtimeOnly) {
-        partialConfig.alias['vue-i18n'] =
-          'vue-i18n/dist/vue-i18n.runtime.esm-bundler.js'
-        debug('set vue-i18n alias')
-      }
 
       if (compositionOnly) {
         partialConfig.define['__VUE_I18N_LEGACY_API__'] = false

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,5 @@
 export type VitePluginVueI18nOptions = {
   forceStringify?: boolean
-  runtimeOnly?: boolean
   compositionOnly?: boolean
   fullInstall?: boolean
   include?: string | string[]


### PR DESCRIPTION
I'll change to `vue-i18n.runtime.esm-bundler.js` for bundler as default,  because we don't configure this option.
https://vue-i18n-next.intlify.dev/advanced/optimization.html#improve-performance-and-reduce-bundle-size-with-runtime-build-only