### PR TITLE
Fix test fail on windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { generateJSON, generateYAML } from '@intlify/cli'
 import { debug as Debug } from 'debug'
 import { parseVueRequest } from './query'
 
-import type { Plugin, ResolvedConfig } from 'vite'
+import { normalizePath, Plugin, ResolvedConfig } from 'vite'
 import type { CodeGenOptions, DevEnv } from '@intlify/cli'
 import type { VitePluginVueI18nOptions } from './options'
 
@@ -27,7 +27,17 @@ function pluginI18n(
 ): Plugin {
   debug('plugin options:', options)
 
-  const filter = createFilter(options.include)
+  // use `normalizePath` for `options.include`
+  let include = options.include
+  if (include) {
+    if (Array.isArray(include)) {
+      include = include.map(item => normalizePath(item))
+    } else if (typeof include === 'string') {
+      include = normalizePath(include)
+    }
+  }
+
+  const filter = createFilter(include)
   const compositionOnly = isBoolean(options.compositionOnly)
     ? options.compositionOnly
     : true


### PR DESCRIPTION
The test `resource-compilation.test.ts` is failing on windows because the `include` path is different from the ones in macos/linux.
A call of `normalizePath` in `vite` can easily fix this.