### PR TITLE
fix: move debug to dependencies, add vite peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@intlify/cli": "^0.2.0",
     "@intlify/shared": "^9.0.0",
     "@rollup/pluginutils": "^4.1.0",
+    "debug": "^4.1.1",
     "fast-glob": "^3.2.5"
   },
   "devDependencies": {
@@ -38,7 +39,6 @@
     "@typescript-eslint/parser": "^4.11.0",
     "@vitejs/plugin-vue": "^1.1.4",
     "@vue/compiler-sfc": "^3.0.5",
-    "debug": "^4.1.1",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-prettier": "^3.3.0",
@@ -78,6 +78,9 @@
   ],
   "license": "MIT",
   "main": "lib/index.js",
+  "peerDependencies": {
+    "vite": "^2.0.1"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/intlify/vite-plugin-vue-i18n.git"


### PR DESCRIPTION
Here is another fix for using `@intlify/vite-plugin-vue-i18n` with yarn 2.

When starting vite I get:

```txt
Error: @intlify/vite-plugin-vue-i18n tried to access debug, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: debug (via "debug")
Required by: @intlify/vite-plugin-vue-i18n@npm:2.0.2 (via ./.yarn/cache/@intlify-vite-plugin-vue-i18n-npm-2.0.2-157305a34b-3e7108929e.zip/node_modules/@intlify/vite-plugin-vue-i18n/lib/)
```

and

```txt
Error: @intlify/vite-plugin-vue-i18n tried to access vite, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: vite (via "vite")
Required by: @intlify/vite-plugin-vue-i18n@npm:2.0.2 (via ./.yarn/cache/@intlify-vite-plugin-vue-i18n-npm-2.0.2-157305a34b-3e7108929e.zip/node_modules/@intlify/vite-plugin-vue-i18n/lib/)
```

I moved `debug` to _dependencies_ and listed `vite` as _peerDependency_ as per the [yarn rulebook](https://next.yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies).

I just copied the `vite` version from _devDependencies_, although I'm pretty sure it works with lower versions, too (I'm still using `vite@2.0.0-beta.55` and it seems to work just fine).
My understanding is that it is best to define the lowest supported version as _peerDependency_, but I don't know which one that actually is.
