### PR TITLE
fix: add vue-i18n peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
   "license": "MIT",
   "main": "lib/index.js",
   "peerDependencies": {
-    "vite": "^2.0.1"
+    "vite": "^2.0.1",
+    "vue-i18n": "^9.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It turns out I missed a dependency in #77.

The error only occurred at runtime and is slightly different because of the dynamic import:

```txt
UnhandledPromiseRejectionWarning: Error: @intlify/vite-plugin-vue-i18n requires vue-i18n to be present in the dependency tree.
```

And when logging the actual error thrown by `import()`:

```txt
(node:165788) UnhandledPromiseRejectionWarning: Error: @intlify/vite-plugin-vue-i18n requires vue-i18n to be present in the dependency tree.



Error: vue-i18n tried to access vue (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.

Required package: vue (via "vue")
Required by: vue-i18n@virtual:ab48c9c8aed85faecc7140c3a679a5a7a52b6b731053a28895a20fa0735ba276d7c62ef7394edfcdaa7d8958d7bc348f0d948ded7730ecdb52f90df29d00a3d4#npm:9.0.0 (via ./.yarn/$$virtual/vue-i18n-virtual-7c24901704/0/cache/vue-i18n-npm-9.0.0-00672d5272-83fe992ac5.zip/node_modules/vue-i18n/dist/)
Ancestor breaking the chain: @intlify/vite-plugin-vue-i18n@patch:@intlify/vite-plugin-vue-i18n@npm%3A2.0.1#./patch.diff::version=2.0.1&hash=ed53f7&locator=redacted
```